### PR TITLE
Add transition for initial state

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -233,7 +233,7 @@ module Statesman
     def initialize(object,
                    options = {
                      transition_class: Statesman::Adapters::MemoryTransition,
-                     initial_transition: false
+                     initial_transition: false,
                    })
       @object = object
       @transition_class = options[:transition_class]
@@ -242,7 +242,7 @@ module Statesman
       )
 
       if options[:initial_transition]
-        @storage_adapter.create(nil, self.class.initial_state, {})
+        @storage_adapter.create(nil, self.class.initial_state)
       end
 
       send(:after_initialize) if respond_to? :after_initialize

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -233,12 +233,18 @@ module Statesman
     def initialize(object,
                    options = {
                      transition_class: Statesman::Adapters::MemoryTransition,
+                     initial_transition: false
                    })
       @object = object
       @transition_class = options[:transition_class]
       @storage_adapter = adapter_class(@transition_class).new(
         @transition_class, object, self, options
       )
+
+      if options[:initial_transition]
+        @storage_adapter.create(nil, self.class.initial_state, {})
+      end
+
       send(:after_initialize) if respond_to? :after_initialize
     end
 

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -242,7 +242,9 @@ module Statesman
       )
 
       if options[:initial_transition]
-        @storage_adapter.create(nil, self.class.initial_state)
+        if history.empty? && self.class.initial_state
+          @storage_adapter.create(nil, self.class.initial_state)
+        end
       end
 
       send(:after_initialize) if respond_to? :after_initialize

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -254,7 +254,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
       end
 
       it "does not raise an error" do
-        expect { check_missing_methods! }.to_not raise_exception(NotImplementedError)
+        expect { check_missing_methods! }.to_not raise_exception
       end
     end
 


### PR DESCRIPTION
This will allow the state machine to track the initial state for the machine, this is important for 3 reasons:
- It allows us to keep a record of how long the state machine spent in the initial state
- If the initial state configuration changes after the state machine transitions from the initial state we still have an accurate record of what the initial state was
- If the initial state configuration changes before the state machine transitions from the initial state we still have an accurate record of what the initial state is